### PR TITLE
fix flatbuffer logic for chunks using vtables for offsets

### DIFF
--- a/src/main/java/no/stelar7/cdragon/types/rman/RMANParser.java
+++ b/src/main/java/no/stelar7/cdragon/types/rman/RMANParser.java
@@ -15,12 +15,12 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class RMANParser implements Parseable<RMANFile>
 {
-    
+
     public enum RMANFileType
     {
         GAME, LCU
     }
-    
+
     public static RMANFile loadFromCache(int version, RMANFileType type)
     {
         try
@@ -32,10 +32,10 @@ public class RMANParser implements Parseable<RMANFile>
                 System.out.println("Manifest not in cache!!");
                 return null;
             }
-            
+
             String     patchManifest = String.join("\n", Files.readAllLines(realPath));
             JsonObject obj           = UtilHandler.getJsonParser().parse(patchManifest).getAsJsonObject();
-            
+
             Path usedManfest = null;
             switch (type)
             {
@@ -47,59 +47,59 @@ public class RMANParser implements Parseable<RMANFile>
                     WebHandler.downloadFile(usedManfest, url);
                     break;
                 }
-                
+
                 case LCU:
                 {
                     System.out.println("Downloading lcu manifest");
                     String url = obj.get("client_patch_url").getAsString();
                     usedManfest = downloadPath.resolveSibling("lcu\\" + version + ".rman");
                     WebHandler.downloadFile(usedManfest, url);
-                    
+
                     break;
                 }
             }
-            
+
             System.out.println("Parsing...");
             return new RMANParser().parse(usedManfest);
-            
+
         } catch (IOException e)
         {
             e.printStackTrace();
             return null;
         }
     }
-    
+
     public static Long getSieveVersion()
     {
         Pair<String, String> urls = getPBEManifestFromSieve();
         return Long.parseLong(urls.getA());
     }
-    
+
     public static List<RMANFile> getSieveManifests()
     {
         List<RMANFile>       files      = new ArrayList<>();
         Pair<String, String> gameData   = getPBEManifestFromSieve();
         String               clientData = getPBEManifestFromClientConfig();
         RMANParser           parser     = new RMANParser();
-        
+
         String version = gameData.getA();
         String url     = gameData.getB();
-        
+
         System.out.println("Downloading manifest " + version);
         Path usedManfest = UtilHandler.CDRAGON_FOLDER.resolve("cdragon").resolve("patcher").resolve("manifests").resolve("sieve\\" + version + "-game.rman");
         System.out.println(usedManfest);
         WebHandler.downloadFile(usedManfest, url);
         files.add(parser.parse(usedManfest));
-        
+
         url = clientData;
         usedManfest = UtilHandler.CDRAGON_FOLDER.resolve("cdragon").resolve("patcher").resolve("manifests").resolve("sieve\\" + version + "-client.rman");
         System.out.println(usedManfest);
         WebHandler.downloadFile(usedManfest, url);
         files.add(parser.parse(usedManfest));
-        
+
         return files;
     }
-    
+
     public static String getPBEManifestFromClientConfig()
     {
         System.out.println("Getting PBE manifest from client config");
@@ -112,7 +112,7 @@ public class RMANParser implements Parseable<RMANFile>
         String     patchUrl  = config.get("patch_url").getAsString();
         return patchUrl;
     }
-    
+
     public static Pair<String, String> getPBEManifestFromSieve()
     {
         System.out.println("Getting PBE manifest from sieve");
@@ -120,31 +120,31 @@ public class RMANParser implements Parseable<RMANFile>
         String     content  = String.join("\n", WebHandler.readWeb(url));
         JsonObject obj      = (JsonObject) UtilHandler.getJsonParser().parse(content);
         JsonArray  releases = obj.getAsJsonArray("releases");
-        
+
         final long[]                            maxVersion      = {0};
         Map<String, List<Pair<String, String>>> patchToManifest = new HashMap<>();
         releases.forEach(e -> {
             String type     = e.getAsJsonObject().getAsJsonObject("release").getAsJsonObject("labels").getAsJsonObject("riot:artifact_type_id").getAsJsonArray("values").get(0).getAsString();
             String version  = e.getAsJsonObject().getAsJsonObject("compat_version").get("id").getAsString();
             String manifest = e.getAsJsonObject().getAsJsonObject("download").get("url").getAsString();
-            
+
             long intVersion = Long.parseLong(version.split("\\+")[0].replace(".", ""));
             if (intVersion > maxVersion[0])
             {
                 maxVersion[0] = intVersion;
             }
-            
+
             patchToManifest.putIfAbsent(version, new ArrayList<>());
             patchToManifest.get(version).add(new Pair<>(type, manifest));
         });
-        
+
         AtomicReference<Pair<String, String>> target = new AtomicReference<>();
         patchToManifest.forEach((k, v) -> {
             if (k.contains("releasedbg"))
             {
                 return;
             }
-            
+
             long intVersion = Long.parseLong(k.split("\\+")[0].replace(".", ""));
             if (intVersion == maxVersion[0])
             {
@@ -156,30 +156,30 @@ public class RMANParser implements Parseable<RMANFile>
                 });
             }
         });
-        
+
         return target.get();
     }
-    
-    
+
+
     public static JsonObject getPBEManifest()
     {
         try
         {
             Path downloadPath = UtilHandler.CDRAGON_FOLDER.resolve("cdragon\\patcher\\manifests").resolve(UUID.randomUUID().toString());
             Files.createDirectories(downloadPath.getParent());
-            
+
             System.out.println("Downloading patcher manifest");
             //String patcherUrl = "https://ks-foundation.dyn.riotcdn.net/channels/public/pbe-pbe-win.json";
             //String patcherUrl = "https://sieve.services.riotcdn.net/api/v1/products/lol/version-sets/PBE1?q[artifact_type_id]=lol-game-client&q[platform]=windows&q[published]=true";
             String patcherUrl = "https://lol.dyn.riotcdn.net/channels/public/pbe-pbe-win.json";
             //String patcherUrl = "https://lol.dyn.riotcdn.net/channels/public/macpbe-pbe-mac.json";
             WebHandler.downloadFile(downloadPath, patcherUrl);
-            
+
             String     patchManifest = String.join("\n", Files.readAllLines(downloadPath));
             JsonObject obj           = UtilHandler.getJsonParser().parse(patchManifest).getAsJsonObject();
             int        version       = obj.get("version").getAsInt();
             System.out.println("Found patch version " + version);
-            
+
             Path realPath = downloadPath.resolveSibling(version + ".json");
             if (Files.exists(realPath))
             {
@@ -190,22 +190,22 @@ public class RMANParser implements Parseable<RMANFile>
                 System.out.println("Saving file");
                 Files.move(downloadPath, realPath);
             }
-            
+
             obj.addProperty("localsavepath", realPath.toString());
             return obj;
         } catch (IOException e)
         {
             e.printStackTrace();
         }
-        
+
         return null;
     }
-    
+
     public static RMANFile loadFromPBE(JsonObject obj, RMANFileType type)
     {
         Path   downloadPath = Paths.get(obj.get("localsavepath").getAsString());
         String version      = obj.get("version").getAsString();
-        
+
         Path usedManfest = null;
         switch (type)
         {
@@ -217,22 +217,22 @@ public class RMANParser implements Parseable<RMANFile>
                 WebHandler.downloadFile(usedManfest, url);
                 break;
             }
-            
+
             case LCU:
             {
                 System.out.println("Downloading lcu manifest");
                 String url = obj.get("client_patch_url").getAsString();
                 usedManfest = downloadPath.resolveSibling("lcu\\" + version + ".rman");
                 WebHandler.downloadFile(usedManfest, url);
-                
+
                 break;
             }
         }
-        
+
         System.out.println("Parsing...");
         return new RMANParser().parse(usedManfest);
     }
-    
+
     /**
      * the files list on this object only contains the files that have changed between this and last patch
      */
@@ -241,16 +241,16 @@ public class RMANParser implements Parseable<RMANFile>
         try
         {
             Path downloadPath = UtilHandler.CDRAGON_FOLDER.resolve("cdragon\\patcher\\manifests").resolve(UUID.randomUUID().toString());
-            
+
             System.out.println("Downloading patcher manifest");
             String patcherUrl = "https://lol.dyn.riotcdn.net/channels/public/pbe-pbe-win.json";
             WebHandler.downloadFile(downloadPath, patcherUrl);
-            
+
             String     patchManifest = String.join("\n", Files.readAllLines(downloadPath));
             JsonObject obj           = UtilHandler.getJsonParser().parse(patchManifest).getAsJsonObject();
             int        version       = obj.get("version").getAsInt();
             System.out.println("Found patch version " + version);
-            
+
             Path realPath = downloadPath.resolveSibling(version + ".json");
             if (Files.exists(realPath))
             {
@@ -261,7 +261,7 @@ public class RMANParser implements Parseable<RMANFile>
                 System.out.println("Saving file");
                 Files.move(downloadPath, realPath);
             }
-            
+
             Path usedManfest = null;
             switch (type)
             {
@@ -273,7 +273,7 @@ public class RMANParser implements Parseable<RMANFile>
                     WebHandler.downloadFile(usedManfest, url);
                     break;
                 }
-                
+
                 case LCU:
                 {
                     System.out.println("Downloading lcu manifest");
@@ -283,7 +283,7 @@ public class RMANParser implements Parseable<RMANFile>
                     break;
                 }
             }
-            
+
             System.out.println("Parsing...");
             RMANFile newFile = new RMANParser().parse(usedManfest);
             RMANFile oldFile = RMANParser.loadFromCache(version - 1, type);
@@ -294,57 +294,57 @@ public class RMANParser implements Parseable<RMANFile>
                 newFile.getBody().getFiles().removeIf(nfif -> oldFiles.stream().map(RMANFileBodyFile::getFileId).noneMatch(i -> nfif.getFileId() == i));
                 System.out.println();
             }
-            
+
             return newFile;
-            
+
         } catch (IOException e)
         {
             e.printStackTrace();
             return null;
         }
     }
-    
+
     public static RMANFile getFromURL(String url)
     {
         ByteArrayOutputStream stream = WebHandler.downloadFileToMemory(url);
         ByteArray             data   = new ByteArray(stream.toByteArray());
-        
+
         return new RMANParser().parse(data);
     }
-    
+
     @Override
     public RMANFile parse(Path path)
     {
         return parse(new RandomAccessReader(path, ByteOrder.LITTLE_ENDIAN));
     }
-    
+
     @Override
     public RMANFile parse(ByteArray data)
     {
         return parse(new RandomAccessReader(data.getDataRaw(), ByteOrder.LITTLE_ENDIAN));
     }
-    
+
     @Override
     public RMANFile parse(RandomAccessReader raf)
     {
         RMANFile file = new RMANFile();
         file.setHeader(parseHeader(raf));
-        
+
         raf.seek(file.getHeader().getOffset());
         file.setCompressedBody(raf.readBytes(file.getHeader().getLength()));
-        
+
         if (file.getHeader().getSignatureType() != 0)
         {
             file.setSignature(raf.readBytes(256));
         }
-        
+
         file.setBody(parseCompressedBody(file));
         file.buildChunkMap();
         file.buildBundleMap();
-        
+
         return file;
     }
-    
+
     private RMANFileBody parseCompressedBody(RMANFile file)
     {
         byte[]             uncompressed = CompressionHandler.uncompressZSTD(file.getCompressedBody(), file.getHeader().getDecompressedLength());
@@ -352,63 +352,63 @@ public class RMANParser implements Parseable<RMANFile>
         RMANFileBody       body         = new RMANFileBody();
         body.setHeaderOffset(raf.readInt());
         raf.seek(body.getHeaderOffset());
-        
+
         RMANFileBodyHeader header = new RMANFileBodyHeader();
         header.setOffsetTableOffset(raf.readInt());
-        
+
         int offset = raf.readInt();
         raf.seek(raf.pos() + offset);
         header.setBundleListOffset(raf.pos() - 4);
         raf.seek(raf.pos() - offset);
-        
+
         offset = raf.readInt();
         raf.seek(raf.pos() + offset);
         header.setLanguageListOffset(raf.pos() - 4);
         raf.seek(raf.pos() - offset);
-        
+
         offset = raf.readInt();
         raf.seek(raf.pos() + offset);
         header.setFileListOffset(raf.pos() - 4);
         raf.seek(raf.pos() - offset);
-        
+
         offset = raf.readInt();
         raf.seek(raf.pos() + offset);
         header.setFolderListOffset(raf.pos() - 4);
         raf.seek(raf.pos() - offset);
-        
+
         offset = raf.readInt();
         raf.seek(raf.pos() + offset);
         header.setKeyHeaderOffset(raf.pos() - 4);
         raf.seek(raf.pos() - offset);
-        
+
         offset = raf.readInt();
         raf.seek(raf.pos() + offset);
         header.setUnknownOffset(raf.pos() - 4);
         raf.seek(raf.pos() - offset);
-        
+
         body.setHeader(header);
         body.setBundles(parseBundles(raf, header));
         body.setLanguages(parseLanguages(raf, header));
         body.setFiles(parseFiles(raf, header));
         body.setDirectories(parseDirectories(raf, header));
-        
+
         return body;
     }
-    
+
     private List<RMANFileBodyDirectory> parseDirectories(RandomAccessReader raf, RMANFileBodyHeader header)
     {
         List<RMANFileBodyDirectory> data = new ArrayList<>();
         raf.seek(header.getFolderListOffset());
-        
+
         int count = raf.readInt();
         for (int i = 0; i < count; i++)
         {
             RMANFileBodyDirectory dir = new RMANFileBodyDirectory();
-            
+
             dir.setOffset(raf.readInt());
             int nextFileOffset = raf.pos();
             raf.seek(nextFileOffset + dir.getOffset() - 4);
-            
+
             dir.setOffsetTableOffset(raf.readInt());
             int resumeOffset = raf.pos();
             raf.seek(raf.pos() - dir.getOffsetTableOffset());
@@ -419,43 +419,43 @@ public class RMANParser implements Parseable<RMANFile>
             raf.seek(raf.pos() + dir.getNameOffset() - 4);
             dir.setName(raf.readString(raf.readInt()));
             raf.seek(nextFileOffset + dir.getOffset() + 4);
-            
+
             if (dir.getDirectoryIdOffset() > 0)
             {
                 dir.setDirectoryId(raf.readLong());
             }
-            
+
             if (dir.getParentIdOffset() > 0)
             {
                 dir.setParentId(raf.readLong());
             }
-            
+
             raf.seek(nextFileOffset);
             data.add(dir);
         }
-        
+
         return data;
     }
-    
+
     private List<RMANFileBodyFile> parseFiles(RandomAccessReader raf, RMANFileBodyHeader header)
     {
         List<RMANFileBodyFile> data = new ArrayList<>();
         raf.seek(header.getFileListOffset());
-        
+
         int count = raf.readInt();
         for (int i = 0; i < count; i++)
         {
             RMANFileBodyFile bfile = new RMANFileBodyFile();
-            
+
             bfile.setOffset(raf.readInt());
             int nextFileOffset = raf.pos();
             raf.seek(nextFileOffset + bfile.getOffset() - 4);
-            
+
             bfile.setOffsetTableOffset(raf.readInt());
-            
+
             int tempA         = raf.readInt();
             int restoreOffset = 4;
-            
+
             bfile.setCustomNameOffset(tempA & 0xFFFFFF);
             bfile.setFiletypeFlag(tempA >> 24);
             boolean hasInlineName = raf.readInt() < 100;
@@ -468,35 +468,35 @@ public class RMANParser implements Parseable<RMANFile>
                 bfile.setNameOffset(raf.readInt());
                 restoreOffset = 8;
             }
-            
+
             raf.seek(raf.pos() + bfile.getNameOffset() - 4);
             bfile.setName(raf.readString(raf.readInt()));
             raf.seek(nextFileOffset + bfile.getOffset() + restoreOffset);
-            
+
             bfile.setStructSize(raf.readInt());
-            
+
             bfile.setSymlinkOffset(raf.readInt());
             raf.seek(raf.pos() + bfile.getSymlinkOffset() - 4);
             bfile.setSymlink(raf.readString(raf.readInt()));
             raf.seek(nextFileOffset + bfile.getOffset() + 8 + restoreOffset);
-            
+
             bfile.setFileId(raf.readLong());
-            
+
             if (bfile.getStructSize() > 28)
             {
                 bfile.setDirectoryId(raf.readLong());
             }
-            
+
             bfile.setFileSize(raf.readInt());
             bfile.setPermissions(raf.readInt());
-            
+
             if (bfile.getStructSize() > 36)
             {
                 bfile.setLanguageId(raf.readInt());
                 bfile.setUnknown2(raf.readInt());
             }
-            
-            
+
+
             bfile.setSingleChunk(raf.readInt());
             if (!bfile.isSingleChunk())
             {
@@ -506,89 +506,108 @@ public class RMANParser implements Parseable<RMANFile>
                 bfile.setChunkIds(Collections.singletonList(raf.readLong()));
                 bfile.setUnknown3(raf.readInt());
             }
-            
+
             raf.seek(nextFileOffset);
             data.add(bfile);
         }
-        
+
         return data;
     }
-    
+
     private List<RMANFileBodyLanguage> parseLanguages(RandomAccessReader raf, RMANFileBodyHeader header)
     {
         List<RMANFileBodyLanguage> data = new ArrayList<>();
         raf.seek(header.getLanguageListOffset());
-        
+
         int count = raf.readInt();
         for (int i = 0; i < count; i++)
         {
             RMANFileBodyLanguage language = new RMANFileBodyLanguage();
-            
+
             language.setOffset(raf.readInt());
             int nextLanguageOffset = raf.pos();
             raf.seek(nextLanguageOffset + language.getOffset() - 4);
-            
+
             language.setOffsetTableOffset(raf.readInt());
             language.setId(raf.readInt());
             language.setNameOffset(raf.readInt());
             raf.seek(raf.pos() + language.getNameOffset() - 4);
             language.setName(raf.readString(raf.readInt()));
-            
+
             raf.seek(nextLanguageOffset);
             data.add(language);
         }
-        
+
         return data;
     }
-    
+
     private List<RMANFileBodyBundle> parseBundles(RandomAccessReader raf, RMANFileBodyHeader header)
     {
         List<RMANFileBodyBundle> data = new ArrayList<>();
         raf.seek(header.getBundleListOffset());
-        
+
         int count = raf.readInt();
         for (int i = 0; i < count; i++)
         {
             RMANFileBodyBundle bundle = new RMANFileBodyBundle();
-            
+
             bundle.setOffset(raf.readInt());
             int nextBundleOffset = raf.pos();
             raf.seek(nextBundleOffset + bundle.getOffset() - 4);
-            
+
             bundle.setOffsetTableOffset(raf.readInt());
             bundle.setHeaderSize(raf.readInt());
-            bundle.setBundleId(HashHandler.toHex(raf.readLong(), 16));
             if (bundle.getHeaderSize() > 12)
             {
                 bundle.setSkipped(raf.readBytes(bundle.getHeaderSize() - 12));
             }
-            
+
+            raf.seek(nextBundleOffset + (bundle.getOffset() - bundle.getOffsetTableOffset() - 4));
+            RMANVTable rmanvTable = new RMANVTable();
+            rmanvTable.setSize(raf.readShort());
+            rmanvTable.setObjects(raf.readShort());
+            int[] offsets =new int[rmanvTable.getObjects()];
+            for (int j = 0; j < offsets.length; j++) {
+                offsets[j]=raf.readShort();
+            }
+            rmanvTable.setOffsets(offsets);
+            bundle.setVTable(rmanvTable);
+
+            raf.seek(nextBundleOffset + bundle.getOffset() -4 + bundle.getVTable().getOffsets()[0]);
+            bundle.setBundleId(HashHandler.toHex(raf.readLong(), 16));
+
+            raf.seek(nextBundleOffset + bundle.getOffset() -4 + bundle.getVTable().getOffsets()[1]);
+            int chunkOffsetOffset = raf.readInt();
+
+            raf.seek(nextBundleOffset + bundle.getOffset() -4 + bundle.getVTable().getOffsets()[1] + chunkOffsetOffset);
+            int chunkOffsetLength = raf.readInt();
+
+
             List<RMANFileBodyBundleChunk> chunks     = new ArrayList<>();
-            int                           chunkCount = raf.readInt();
-            for (int j = 0; j < chunkCount; j++)
+            for (int j = 0; j < chunkOffsetLength; j++)
             {
                 int chunkOffset     = raf.readInt();
                 int nextChunkOffset = raf.pos();
                 raf.seek(chunkOffset + nextChunkOffset - 4);
-                
+
                 RMANFileBodyBundleChunk chunk = new RMANFileBodyBundleChunk();
                 chunk.setOffsetTableOffset(raf.readInt());
                 chunk.setCompressedSize(raf.readInt());
                 chunk.setUncompressedSize(raf.readInt());
                 chunk.setChunkId(HashHandler.toHex(raf.readLong(), 16));
                 chunks.add(chunk);
-                
+
                 raf.seek(nextChunkOffset);
             }
-            
+
             bundle.setChunks(chunks);
             raf.seek(nextBundleOffset);
             data.add(bundle);
         }
-        
+
         return data;
     }
-    
+
     private RMANFileHeader parseHeader(RandomAccessReader raf)
     {
         RMANFileHeader header = new RMANFileHeader();

--- a/src/main/java/no/stelar7/cdragon/types/rman/data/RMANFileBodyBundle.java
+++ b/src/main/java/no/stelar7/cdragon/types/rman/data/RMANFileBodyBundle.java
@@ -9,6 +9,7 @@ public class RMANFileBodyBundle
     private int                           headerSize;
     private String                        bundleId;
     private byte[]                        skipped;
+    private RMANVTable                    vTable;
     private List<RMANFileBodyBundleChunk> chunks;
     
     public int getOffset()
@@ -70,7 +71,17 @@ public class RMANFileBodyBundle
     {
         this.chunks = chunks;
     }
-    
+
+    public RMANVTable getVTable()
+    {
+        return vTable;
+    }
+
+    public void setVTable(RMANVTable vTable)
+    {
+        this.vTable = vTable;
+    }
+
     @Override
     public boolean equals(Object o)
     {

--- a/src/main/java/no/stelar7/cdragon/types/rman/data/RMANVTable.java
+++ b/src/main/java/no/stelar7/cdragon/types/rman/data/RMANVTable.java
@@ -1,0 +1,56 @@
+package no.stelar7.cdragon.types.rman.data;
+
+import java.util.Arrays;
+
+/**
+ * Created: 04/08/2023 11:54
+ * Author: hawolt
+ * Reference: see Table section https://flatbuffers.dev/flatbuffers_internals.html
+ **/
+
+public class RMANVTable
+{
+    private int   objects;
+    private int   size;
+    private int[] offsets;
+
+    public int getObjects()
+    {
+        return objects;
+    }
+
+    public void setObjects(int objects)
+    {
+        this.objects = objects;
+    }
+
+    public int getSize()
+    {
+        return size;
+    }
+
+    public void setSize(int size)
+    {
+        this.size = size;
+    }
+
+    public int[] getOffsets()
+    {
+        return offsets;
+    }
+
+    public void setOffsets(int[] offsets)
+    {
+        this.offsets = offsets;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "VTable{" +
+                "objects=" + objects +
+                ", size=" + size +
+                ", offsets=" + Arrays.toString(offsets) +
+                '}';
+    }
+}


### PR DESCRIPTION
fixed an issue with the reader going out of the bodys bounds for some manifests when reading chunk data by using the proper offsets given by the flatbuffer vtable